### PR TITLE
check if filters are enabled before writing value

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -568,8 +568,14 @@ TABS.pid_tuning.initialize = function (callback) {
 
         RC_tuning.dynamic_THR_PID = parseFloat($('.tpa input[name="tpa"]').val());
         RC_tuning.dynamic_THR_breakpoint = parseInt($('.tpa input[name="tpa-breakpoint"]').val());
-        FILTER_CONFIG.gyro_lowpass_hz = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());        
-        FILTER_CONFIG.dterm_lowpass_hz = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
+        
+        if (!$('.pid_filter input[name="gyroLowpassFrequency"]').prop('disabled')) {
+            FILTER_CONFIG.gyro_lowpass_hz = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());
+        }
+        if (!$('.pid_filter input[name="dtermLowpassFrequency"]').prop('disabled')) {
+            FILTER_CONFIG.dterm_lowpass_hz = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
+        }
+	    
         FILTER_CONFIG.yaw_lowpass_hz = parseInt($('.pid_filter input[name="yawLowpassFrequency"]').val());
 
         if (semver.gte(CONFIG.apiVersion, "1.16.0") && !semver.gte(CONFIG.apiVersion, "1.20.0")) {


### PR DESCRIPTION
I noticed that after every save in the pids tab the values dterm_lowpass_hz and gyro_lowpass_hz are set to 0. This happens because the field is set to 0 when the filter is disabled and is written back with the next save.

Now the value is not changed if the field is disabled and this prevents changing the value from the default value to 0.

Might be releated to #1082